### PR TITLE
Package name for removed packages missing in JSON output

### DIFF
--- a/sbomdiff/cli.py
+++ b/sbomdiff/cli.py
@@ -186,6 +186,7 @@ def main(argv=None):
         else:
             # Package must have been removed
             version1, license1 = packages1[package]
+            package_info["package"] = package
             if len(version1) == 0:
                 version1 = "UNKNOWN"
             if args["format"] == "text":


### PR DESCRIPTION
As the title says.

This tool seems pretty useful, however the JSON output wasn't specifying which package got removed. This should fix that.