### PR TITLE
Update spdx_parser.py to handle spdx file parsing logic to generate correct key value pair of dictionary

### DIFF
--- a/sbomdiff/spdx_parser.py
+++ b/sbomdiff/spdx_parser.py
@@ -34,16 +34,31 @@ class SPDXParser:
         packages = {}
         package = ""
         version = None
+        githubStr = "pkg.go.dev/"
         for line in lines:
             line_elements = line.split(":")
             if line_elements[0] == "PackageName":
+                isProductNameWithOnlyVersionNumber = False
                 package = line_elements[1].strip().rstrip("\n")
+                productNameWithOnlyVersionNumber = re.compile(r'(/)')
+                if bool(productNameWithOnlyVersionNumber.search(package)) != True:
+                    isProductNameWithOnlyVersionNumber = True
                 version = None
                 license = None
             if line_elements[0] == "PackageVersion":
                 version = line[16:].strip().rstrip("\n")
             if line_elements[0] == "PackageLicenseConcluded":
                 license = line_elements[1].strip().rstrip("\n")
+            if line_elements[0] == "PackageHomePage":
+                packageHomePage = line_elements[1].strip().rstrip("\n")
+                packageHomePageRemaining = ""
+                if len(line_elements) > 2 :
+                    packageHomePageRemaining = line_elements[2].strip().rstrip("\n")
+                packageHomePage = packageHomePage + packageHomePageRemaining
+                if isProductNameWithOnlyVersionNumber:
+                    tempArry = packageHomePage.split(githubStr)
+                    if len(tempArry) == 2:
+                        package = tempArry[1]
             if package not in packages and version is not None and license is not None:
                 packages[package] = [version, license]
 


### PR DESCRIPTION
**Problem statement:** 
------------------------
Showing same software b/w two SPDX file as diff and generating result with same product removed then later added back. 

**If spdx file [1] contains:** 
```
#### Package: cloud.google.com/go/networksecurity

PackageName: cloud.google.com/go/networksecurity
SPDXID: SPDXRef-Pkg-cloud.google.com-go-networksecurity-v0.6.0-5311591
PackageVersion: v0.6.0
PackageSupplier: Organization: go:cloud.google.com/go/networksecurity
PackageHomePage: https://pkg.go.dev/cloud.google.com/go/networksecurity
PackageDownloadLocation: NOASSERTION
PackageLicenseConcluded: Apache-2.0
PackageLicenseDeclared: Apache-2.0
PackageCopyrightText: NOASSERTION
FilesAnalyzed: False
ExternalRef: PACKAGE-MANAGER purl pkg:golang/cloud.google.com/go/networksecurity@v0.6.0
```

**If spdx file [2] contains:**
 
```
#### Package: networksecurity

PackageName: networksecurity
SPDXID: SPDXRef-Pkg-cloud.google.com-go-networksecurity-v0.5.0-5311454
PackageVersion: v0.5.0
PackageSupplier: Organization: go:cloud.google.com/go/networksecurity
PackageHomePage: https://pkg.go.dev/cloud.google.com/go/networksecurity
PackageDownloadLocation: NOASSERTION
PackageLicenseConcluded: Apache-2.0
PackageLicenseDeclared: Apache-2.0
PackageCopyrightText: NOASSERTION
FilesAnalyzed: False
ExternalRef: PACKAGE-MANAGER purl pkg:golang/cloud.google.com/go/networksecurity@v0.5.0
```

**Command used to generate report:** 
----------------------------------------
#python ./cli.py --sbom spdx -o sbom_diff_reports.txt -f text file1.spdx file2.spdx
#echo $?
#1

# cat sbom_diff_reports.txt
```
[REMOVED] networksecurity: (Version v0.5.0)
[ADDED  ] cloud.google.com/go/networksecurity: (Version v0.6.0) (License Apache-2.0)
Summary
-------
Version changes:  0
License changes:  0
Removed packages: 1
New packages:     1
```

**Solution:**
----------
Addition regex logic will help to find right delta between two SPDX file. Without this fix sometime ProductName getting recorded incorrectly as "v2" or "without full path of software" this enhancement will help to detect same product name b/w two spdx file(s).

With fix report contains will be like: 

# cat sbom_diff_reports.txt
```
[REMOVED] networksecurity: (Version v0.5.0)
[ADDED  ] cloud.google.com/go/networksecurity: (Version v0.5.0) (License Apache-2.0)
Summary
-------
Version changes:  1
License changes:  0
Removed packages: 0
New packages:     0
```

Reviewers: 

@anthonyharrison @briancaine 